### PR TITLE
Stop syncing module canonical from json

### DIFF
--- a/test_sync_scripts.py
+++ b/test_sync_scripts.py
@@ -323,7 +323,6 @@ def test_update_metadata(tmp_path, mocker):
                 <md:title>Test module</md:title>
                 <md:abstract/>
             <md:uuid>00000000-0000-0000-0000-000000000001</md:uuid>
-            <md:canonical-book-uuid>00000000-0000-0000-0000-000000000000</md:canonical-book-uuid>
             </metadata>
         </document>
     """

--- a/update_metadata.py
+++ b/update_metadata.py
@@ -15,8 +15,7 @@ MODULE_METADATA_ACCEPT_TAGS = [
     f"{{{NS_MDML}}}content-id"
 ]
 MODULE_METADATA_ADDED_TAGS_FROM_JSON = {
-    "id": "uuid",
-    "canonical": "canonical-book-uuid"
+    "id": "uuid"
 }
 COLLECTION_METADATA_ACCEPT_TAGS = [
     f"{{{NS_MDML}}}title",


### PR DESCRIPTION
Note: Depends on openstax/output-producer-service#290

This PR was accidentally closed from the side effect of https://github.com/openstax/output-producer-service/pull/295/files